### PR TITLE
Fix eating CPU while tracking changes

### DIFF
--- a/test-refresh/src/com/jakemccrary/test_refresh.clj
+++ b/test-refresh/src/com/jakemccrary/test_refresh.clj
@@ -134,7 +134,7 @@
               (when (should-notify? result)
                 (when should-growl
                   (growl (:status result) (:message result)))
-                (users-notifier (:message result)))
-              (Thread/sleep 200)))
-          (catch Exception ex (.printStackTrace ex)))
+                (users-notifier (:message result)))))
+          (catch Exception ex (.printStackTrace ex))
+          (Thread/sleep 200))
         (recur new-tracker)))))


### PR DESCRIPTION
Moved the Thread/sleep in such a way it is always performed, instead of only when a change was tracked.
