### PR TITLE
Skip tests differently when using :test-selectors

### DIFF
--- a/test-refresh/src/com/jakemccrary/test_refresh.clj
+++ b/test-refresh/src/com/jakemccrary/test_refresh.clj
@@ -89,19 +89,6 @@
     (swap! failed-tests update-tracked-failing-tests clojure.test/*testing-vars*)
     (fail x)))
 
-(defn match [test-var [selector args]]
-  (let [form (if (vector? selector)
-               (second selector)
-               selector)
-        selector-fn (eval form)]
-    (apply selector-fn
-      (merge (-> test-var meta :ns meta)
-             (assoc (meta test-var) :leiningen.test/var test-var))
-      args)))
-
-(defn selected? [selectors test-var]
-  (some #(match test-var %) selectors))
-
 (def suppress-unselected-tests
   "A function that figures out which vars need to be suppressed based on the
   given selectors, moves their :test metadata to :leiningen/skipped-test (so


### PR DESCRIPTION
Hi,

This is pretty much a direct port of https://github.com/gfredericks/leiningen/commit/08eaf70781a72d84bc776f99a0592782a94e7b2a 
with some demacro'ing. 

This prevents test-refresh from running the fixtures associated with tests in ignored namespaces.