### PR TITLE
Jdslavin reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ your `clojure.test` tests when a file in your project changes
 - Can optionally suppress `clojure.test`'s _Testing namespace_ output.
   This is extremely useful in making test output with larger codebases readable again.
 - You can hit `enter` in terminal to force tests to rerun.
+- Supports `clojure.test`'s custom reports.
 
 ## Usage
 
@@ -98,6 +99,7 @@ configuration map to supporess `clojure.test`'s noisy output. This is
 particularly useful on codebases with a large number of test namespaces.
 
 ### Custom Clojure.test report
+
 `lein-test-refresh` can be configured to use a custom `clojure.test`
 output report. Add `:report myreport.namespace/myreport` to your `:test-refresh`
 configuration map to use your own reporter for `clojure.test`'s  output. An

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ _Testing namespace_ output. Add `:quiet true` to your `:test-refresh`
 configuration map to supporess `clojure.test`'s noisy output. This is
 particularly useful on codebases with a large number of test namespaces.
 
+### Custom Clojure.test report
+`lein-test-refresh` can be configured to use a custom `clojure.test`
+output report. Add `:report myreport.namespace/myreport` to your `:test-refresh`
+configuration map to use your own reporter for `clojure.test`'s  output. An
+example can be found in the [sample project.clj](sample.project.clj).
+
 ## Latest version & Change log
 
 The latest version is the highest non-snapshot version found in

--- a/lein2/project.clj
+++ b/lein2/project.clj
@@ -9,4 +9,5 @@
                    :unit (complement :integration)}
   :test-refresh {;;:notify-command ["say" "-v" "Agnes"]
                  :notify-on-success false
-                 :quiet true})
+                 ;:quiet true
+                 :report lein2.sample-report/my-report})

--- a/lein2/src/lein2/sample_report.clj
+++ b/lein2/src/lein2/sample_report.clj
@@ -1,0 +1,42 @@
+(ns lein2.sample-report
+    (:require [clojure.test :as t]))
+
+
+(defmulti ^:dynamic my-report :type)
+
+(defmethod my-report :default [m])
+
+(defmethod my-report :pass [m]
+           (t/with-test-out
+             (t/inc-report-counter :pass)))
+
+(defmethod my-report :error [m]
+           (t/with-test-out
+             (t/inc-report-counter :error)
+             (println "\nERROR in" (t/testing-vars-str m))
+             (when-let [message (:message m)] (println message))
+             (println "expected:" (pr-str (:expected m)))
+             (println "  actual:" (pr-str (:actual m)))
+             (println)))
+
+(defmethod my-report :fail [m]
+           (t/with-test-out
+             (t/inc-report-counter :fail)
+             (println "\nFAIL in" (t/testing-vars-str m))
+             (when-let [message (:message m)] (println message))
+             (println "expected:" (pr-str (:expected m)))
+             (println "  actual:" (pr-str (:actual m)))
+             (println)))
+
+(defmethod my-report :begin-test-ns [m]
+           (t/with-test-out
+             (println "\nTesting" (ns-name (:ns m)))))
+
+(defmethod my-report :end-test-ns [m])
+
+(defmethod my-report :summary [m]
+           (t/with-test-out
+             (println "\nRan" (:test m) "tests containing"
+                      (+ (:pass m) (:fail m) (:error m)) "assertions.")
+             (println (:fail m) "failures," (:error m) "errors.")))
+

--- a/sample.project.clj
+++ b/sample.project.clj
@@ -27,5 +27,5 @@
                  ;; Specify the namespace and multimethod that will handle reporting
                  ;; from test-refresh.  The namespace must be available to the project dependencies.
                  ;; Defaults to no custom reporter
-                 :report  "myreport.namespace/my-report"
+                 :report  myreport.namespace/my-report
                  })

--- a/sample.project.clj
+++ b/sample.project.clj
@@ -21,4 +21,11 @@
                  ;; "Testing namespace.being.tested". Very useful on
                  ;; codebases with many test namespaces.
                  ;; Defaults to false.
-                 :quiet true})
+                 :quiet true
+
+                 ;; specifiy a custom clojure.test report method
+                 ;; Specify the namespace and multimethod that will handle reporting
+                 ;; from test-refresh.  The namespace must be available to the project dependencies.
+                 ;; Defaults to no custom reporter
+                 :report  "myreport.namespace/my-report"
+                 })

--- a/test-refresh/project.clj
+++ b/test-refresh/project.clj
@@ -1,4 +1,4 @@
-(defproject com.jakemccrary/lein-test-refresh "0.10.1-SNAPSHOT"
+(defproject com.jakemccrary/lein-test-refresh "0.10.2-SNAPSHOT"
   :description "Automatically reload code and run clojure.test tests when files change"
   :url "https://github.com/jakemcc/lein-test-refresh"
   :developer "Jake McCrary"

--- a/test-refresh/src/com/jakemccrary/test_refresh.clj
+++ b/test-refresh/src/com/jakemccrary/test_refresh.clj
@@ -120,7 +120,7 @@
 
 
 (defn- select-reporting-fn
-       "Sects the reporting function based on user specified configuration"
+       "Selects the reporting function based on user specified configuration"
        [report]
        (when report (require (symbol (namespace (symbol report)))))
        (let [resolved-report (when report (let [rr (resolve (symbol report))]

--- a/test-refresh/src/leiningen/test_refresh.clj
+++ b/test-refresh/src/leiningen/test_refresh.clj
@@ -14,7 +14,7 @@
                (:test-paths project []))))
 
 (defn parse-commandline [project args]
-  (let [{:keys [notify-command notify-on-success growl silence quiet]} (:test-refresh project)
+  (let [{:keys [notify-command notify-on-success growl silence quiet report]} (:test-refresh project)
         should-growl (or (some #{:growl ":growl" "growl"} args) growl)
         args (remove #{:growl ":growl" "growl"} args)
         notify-on-success (or (nil? notify-on-success) notify-on-success)
@@ -24,7 +24,9 @@
      :notify-command notify-command
      :nses-and-selectors (#'test/read-args args project)
      :test-paths (clojure-test-directories project)
-     :quiet quiet}))
+     :quiet quiet
+     :report report
+     }))
 
 (defn test-refresh
   "Autoruns clojure.test tests on source change or

--- a/test-refresh/src/leiningen/test_refresh.clj
+++ b/test-refresh/src/leiningen/test_refresh.clj
@@ -25,8 +25,7 @@
      :nses-and-selectors (#'test/read-args args project)
      :test-paths (clojure-test-directories project)
      :quiet quiet
-     :report report
-     }))
+     :report report}))
 
 (defn test-refresh
   "Autoruns clojure.test tests on source change or

--- a/test-refresh/test/com/jakemccrary/test_refresh_test.clj
+++ b/test-refresh/test/com/jakemccrary/test_refresh_test.clj
@@ -2,27 +2,27 @@
   (:require [com.jakemccrary.test-refresh :refer :all]
             [clojure.test :refer :all]))
 
-;(deftest test-should-notify?
-;  (testing "if notify-on-success is true then all results should notify"
-;    (is (should-notify? true {:status "Passed" :message "Testing"}))
-;    (is (should-notify? true {:status "Failed" :message "Testing"}))
-;    (is (should-notify? true {:status "Error" :message "Testing"})))
-;
-;  (testing "when notify-on-success false then Passed results do not notify"
-;    (is (not (should-notify? false {:status "Passed" :message "Testing"})))
-;    (is (should-notify? false {:status "Failed" :message "Testing"}))
-;    (is (should-notify? false {:status "Error" :message "Testing"}))))
-;
-;(defn a-fn [& _] nil)
-;(defn another-fn [& _] nil)
-;
-;(deftest test-selecting-vars
-;  (testing "Selects vars matching selector function"
-;    (with-redefs [a-fn (vary-meta another-fn merge {:integration true})
-;                  another-fn (vary-meta another-fn merge {:fast true})]
-;      (let [vs [#'a-fn #'another-fn]]
-;        (= [#'a-fn] (select-vars :integration vs))
-;        (= [] (select-vars :no-match vs))))))
-;
-;(deftest test-notification
-;  (testing "lololol"))
+(deftest test-should-notify?
+  (testing "if notify-on-success is true then all results should notify"
+    (is (should-notify? true {:status "Passed" :message "Testing"}))
+    (is (should-notify? true {:status "Failed" :message "Testing"}))
+    (is (should-notify? true {:status "Error" :message "Testing"})))
+
+  (testing "when notify-on-success false then Passed results do not notify"
+    (is (not (should-notify? false {:status "Passed" :message "Testing"})))
+    (is (should-notify? false {:status "Failed" :message "Testing"}))
+    (is (should-notify? false {:status "Error" :message "Testing"}))))
+
+(defn a-fn [& _] nil)
+(defn another-fn [& _] nil)
+
+(deftest test-selecting-vars
+  (testing "Selects vars matching selector function"
+    (with-redefs [a-fn (vary-meta another-fn merge {:integration true})
+                  another-fn (vary-meta another-fn merge {:fast true})]
+      (let [vs [#'a-fn #'another-fn]]
+        (= [#'a-fn] (select-vars :integration vs))
+        (= [] (select-vars :no-match vs))))))
+
+(deftest test-notification
+  (testing "lololol"))

--- a/test-refresh/test/com/jakemccrary/test_refresh_test.clj
+++ b/test-refresh/test/com/jakemccrary/test_refresh_test.clj
@@ -2,27 +2,27 @@
   (:require [com.jakemccrary.test-refresh :refer :all]
             [clojure.test :refer :all]))
 
-(deftest test-should-notify?
-  (testing "if notify-on-success is true then all results should notify"
-    (is (should-notify? true {:status "Passed" :message "Testing"}))
-    (is (should-notify? true {:status "Failed" :message "Testing"}))
-    (is (should-notify? true {:status "Error" :message "Testing"})))
-
-  (testing "when notify-on-success false then Passed results do not notify"
-    (is (not (should-notify? false {:status "Passed" :message "Testing"})))
-    (is (should-notify? false {:status "Failed" :message "Testing"}))
-    (is (should-notify? false {:status "Error" :message "Testing"}))))
-
-(defn a-fn [& _] nil)
-(defn another-fn [& _] nil)
-
-(deftest test-selecting-vars
-  (testing "Selects vars matching selector function"
-    (with-redefs [a-fn (vary-meta another-fn merge {:integration true})
-                  another-fn (vary-meta another-fn merge {:fast true})]
-      (let [vs [#'a-fn #'another-fn]]
-        (= [#'a-fn] (select-vars :integration vs))
-        (= [] (select-vars :no-match vs))))))
-
-(deftest test-notification
-  (testing "lololol"))
+;(deftest test-should-notify?
+;  (testing "if notify-on-success is true then all results should notify"
+;    (is (should-notify? true {:status "Passed" :message "Testing"}))
+;    (is (should-notify? true {:status "Failed" :message "Testing"}))
+;    (is (should-notify? true {:status "Error" :message "Testing"})))
+;
+;  (testing "when notify-on-success false then Passed results do not notify"
+;    (is (not (should-notify? false {:status "Passed" :message "Testing"})))
+;    (is (should-notify? false {:status "Failed" :message "Testing"}))
+;    (is (should-notify? false {:status "Error" :message "Testing"}))))
+;
+;(defn a-fn [& _] nil)
+;(defn another-fn [& _] nil)
+;
+;(deftest test-selecting-vars
+;  (testing "Selects vars matching selector function"
+;    (with-redefs [a-fn (vary-meta another-fn merge {:integration true})
+;                  another-fn (vary-meta another-fn merge {:fast true})]
+;      (let [vs [#'a-fn #'another-fn]]
+;        (= [#'a-fn] (select-vars :integration vs))
+;        (= [] (select-vars :no-match vs))))))
+;
+;(deftest test-notification
+;  (testing "lololol"))


### PR DESCRIPTION
I extended lein-test-refresh to allow for a custom clojure.test reporting function written using the standard mulitmethod functions.  I have a reporter that we use to format reports in BDD style output and we wanted to use that same report when running from the leiningen and your lein-test-refresh so i went ahead and extended it to allow me to do this.     I was not sure what version that really belonged to so i just created a 0.10.2-SNAPSHOT as my version for the moment.  This option will cause the quiet option to be ignored and use the custom reporter.

I define my reporter as follows: 

(defmulti ^:dynamic my-report :type)

(defmethod my-report :default [m]
  )

(defmethod my-report :pass [m]
  (t/with-test-out
    (t/inc-report-counter :pass)
    ))

......  

When i specify the :report options i added to the config for lein-test-refresh i can reference this report to display output in any format i wish.

