### PR TITLE
Adding :with-repl option to start a clojure.main/repl in-between test execution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## NEXT
+
+- Can now use the `:with-repl` flag to start a REPL for interacting with your project.
+
 ## 0.13.0
 
 - Adds support for running tests once with the flag `:run-once`.
@@ -111,7 +115,7 @@ test namespace`.
 
 - Nothing. This was an accidental release due to testing the release
   script.
-  
+
 ## 0.3.7
 
 - Change success message to 'Passed all tests'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ your `clojure.test` tests when a file in your project changes
 - Supports `clojure.test`'s custom reports.
 - Supports running your tests once! Useful for taking advantage of
   custom test reporters or quiet output in CI systems.
+- Has optional repl support for changing global state, such as timbre logging levels
 
 [sample.project.clj](sample.project.clj) show optional configuration.
 It and the rest of this readme should be used as documentation as to
@@ -62,10 +63,10 @@ output will look something like this.
     *************** Running tests ***************
 
     <standard clojure.test output>
-    
+
     Failed 1 of 215 assertions
     Finished at 08:25:20.619 (run time: 9.691s)
-    
+
 Your terminal will just stay like that. Fairly often `lein-test-refresh`
 polls the file system to see if anything has changed. When there is a
 change your code is tested again.
@@ -92,7 +93,7 @@ For example, if you want to send OSX notifications using
 you would add the following to your `project.clj` or `profiles.clj`
 
 ```clojure
-:test-refresh {:notify-command ["terminal-notifier" "-title" "Tests" "-message"]} 
+:test-refresh {:notify-command ["terminal-notifier" "-title" "Tests" "-message"]}
 ```
 
 `lein-test-refresh` also has built-in Growl support. To receive Growl
@@ -149,6 +150,16 @@ profiles.clj) or pass it as a command line option. Check out
 `sample.project.clj` for an example of project configuration.
 
 Using it at the command line looks like `lein test-refresh :run-once`.
+
+### Running with a REPL
+
+`lein-test-refresh` can be run with `:with-repl` which will start up a repl
+that you can interact with inbetween test runs. The main reason for this option
+is that sometimes you want to affect global state in your application.
+An example is when you see a test failure, you can call
+`(taoensso.timbre/set-level! :debug)` and see more information.
+
+See [this](https://github.com/jakemcc/lein-test-refresh/pull/50) pull request for details.
 
 ## Contributing
 

--- a/test-refresh/project.clj
+++ b/test-refresh/project.clj
@@ -12,6 +12,6 @@
                                       :username :gpg :password :gpg}]
                         ["releases" {:url "https://clojars.org/repo"
                                      :username :gpg :password :gpg}]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]}}
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]]}}
   :scm {:name "git"
         :url "git@github.com:jakemcc/lein-test-refresh.git"})

--- a/test-refresh/src/com/jakemccrary/test_refresh.clj
+++ b/test-refresh/src/com/jakemccrary/test_refresh.clj
@@ -179,11 +179,11 @@
                       (read-string line)
                       (do (run-test-refresh!) :run-tests))
                     (System/exit 0))))
-        (loop [line (read-line)]
-          (if-not line
+        (loop [c (.read System/in)]
+          (if (= c -1)
             (System/exit 0)
-            (run-test-refresh!))
-          (recur (read-line)))))))
+            (do (run-test-refresh!)
+                (recur (.read System/in)))))))))
 
 (defn- create-user-notifier [notify-command]
   (let [notify-command (if (string? notify-command)

--- a/test-refresh/src/leiningen/test_refresh.clj
+++ b/test-refresh/src/leiningen/test_refresh.clj
@@ -21,6 +21,7 @@
         with-repl? (or (some #{:with-repl ":with-repl" "with-repl"} args) with-repl)
         args (remove #{:growl ":growl" "growl"
                        :changes-only ":changes-only" "changes-only"
+                       :with-repl ":with-repl" "with-repl"
                        :run-once ":run-once" "run-once"} args)
         notify-on-success (or (nil? notify-on-success) notify-on-success)
         selectors (filter keyword? args)]

--- a/test-refresh/src/leiningen/test_refresh.clj
+++ b/test-refresh/src/leiningen/test_refresh.clj
@@ -14,16 +14,16 @@
                (:test-paths project []))))
 
 (defn parse-commandline [project args]
-  (let [{:keys [notify-command notify-on-success growl silence quiet report changes-only run-once]} (:test-refresh project)
+  (let [{:keys [notify-command notify-on-success growl silence quiet report changes-only run-once with-repl]} (:test-refresh project)
         should-growl (or (some #{:growl ":growl" "growl"} args) growl)
         changes-only (or (some #{:changes-only ":changes-only" "changes-only"} args) changes-only)
         run-once? (or (some #{:run-once ":run-once" "run-once"} args) run-once)
+        with-repl? (or (some #{:with-repl ":with-repl" "with-repl"} args) with-repl)
         args (remove #{:growl ":growl" "growl"
                        :changes-only ":changes-only" "changes-only"
                        :run-once ":run-once" "run-once"} args)
         notify-on-success (or (nil? notify-on-success) notify-on-success)
-        selectors (filter keyword? args)
-        ]
+        selectors (filter keyword? args)]
     {:growl should-growl
      :changes-only changes-only
      :notify-on-success notify-on-success
@@ -32,7 +32,8 @@
      :test-paths (clojure-test-directories project)
      :quiet quiet
      :report report
-     :run-once run-once?}))
+     :run-once run-once?
+     :with-repl with-repl?}))
 
 (defn test-refresh
   "Autoruns clojure.test tests on source change or


### PR DESCRIPTION
This isn't necessarily finished, comments/docstrings/README, but I wanted to see if you were receptive to the idea. Let me know if/what you want me to write to finish this up.

The current use case is for changing timbre's log level & ns filters, and it seems like a repl is not all that intrusive.

Either way, awesome tool you got here, thanks!