### PR TITLE
Add :watch-dirs option

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -41,4 +41,9 @@
                  ;; command line option. Reasoning for feature can be
                  ;; found in PR:
                  ;; https://github.com/jakemcc/lein-test-refresh/pull/48
-                 :run-once true})
+                 :run-once true
+
+                 ;; If given, watch for changes only in the given
+                 ;; folders. By default, watches all source and
+                 ;; resources folders.
+                 :watch-dirs ["src"]})

--- a/test-refresh/src/com/jakemccrary/test_refresh.clj
+++ b/test-refresh/src/com/jakemccrary/test_refresh.clj
@@ -15,8 +15,8 @@
   (clojure.tools.namespace.track/tracker))
 
 (let [prev-failed (atom nil)]
-  (defn- scan-for-changes [tracker]
-    (try (let [new-tracker (clojure.tools.namespace.dir/scan tracker)]
+  (defn- scan-for-changes [tracker watch-dirs]
+    (try (let [new-tracker (apply clojure.tools.namespace.dir/scan tracker watch-dirs)]
            (reset! prev-failed false)
            new-tracker)
          (catch Exception e
@@ -223,6 +223,7 @@
         report (:report options)
         run-once? (:run-once options)
         with-repl? (:with-repl options)
+        watch-dirs (:watch-dirs options)
         monitoring? (atom false)]
 
     (when report
@@ -231,7 +232,7 @@
       (defmethod capture-report :begin-test-ns [m]))
 
     (loop [tracker (make-change-tracker)]
-      (let [new-tracker (scan-for-changes tracker)
+      (let [new-tracker (scan-for-changes tracker watch-dirs)
             something-changed? (something-changed? new-tracker tracker)]
         (try
           (when (or @keystroke-pressed something-changed?)

--- a/test-refresh/src/leiningen/test_refresh.clj
+++ b/test-refresh/src/leiningen/test_refresh.clj
@@ -14,7 +14,7 @@
                (:test-paths project []))))
 
 (defn parse-commandline [project args]
-  (let [{:keys [notify-command notify-on-success growl silence quiet report changes-only run-once with-repl]} (:test-refresh project)
+  (let [{:keys [notify-command notify-on-success growl silence quiet report changes-only run-once with-repl watch-dirs]} (:test-refresh project)
         should-growl (or (some #{:growl ":growl" "growl"} args) growl)
         changes-only (or (some #{:changes-only ":changes-only" "changes-only"} args) changes-only)
         run-once? (or (some #{:run-once ":run-once" "run-once"} args) run-once)
@@ -24,7 +24,8 @@
                        :with-repl ":with-repl" "with-repl"
                        :run-once ":run-once" "run-once"} args)
         notify-on-success (or (nil? notify-on-success) notify-on-success)
-        selectors (filter keyword? args)]
+        selectors (filter keyword? args)
+        watch-dirs (or watch-dirs [])]
     {:growl should-growl
      :changes-only changes-only
      :notify-on-success notify-on-success
@@ -34,7 +35,8 @@
      :quiet quiet
      :report report
      :run-once run-once?
-     :with-repl with-repl?}))
+     :with-repl with-repl?
+     :watch-dirs watch-dirs}))
 
 (defn test-refresh
   "Autoruns clojure.test tests on source change or


### PR DESCRIPTION
By default, test-refresh re-runs the test whenever a file in any of the source or resources directories changed. I have a use case where running my specs modifies resources, so the result is that the tests keep triggering themselves.

The proposed solution is to give an optional whitelist of folders to watch, so I can ignore changes in some of the resources folders.