### PR TITLE
merge :base profile

### DIFF
--- a/test-refresh/src/leiningen/test_refresh.clj
+++ b/test-refresh/src/leiningen/test_refresh.clj
@@ -56,7 +56,7 @@
   Reports results to growl and STDOUT."
   [project & args]
   (let [project (-> project
-                    (project/merge-profiles [:test])
+                    (project/merge-profiles [:base :test])
                     add-deps)
         {:keys [test-paths] :as options} (project-options project args)]
     (eval/eval-in-project


### PR DESCRIPTION
When running test-refresh with another profile like `lein with-profile dev test-refresh`, test-refresh doesn't run any tests.
You can reproduce it by running it under lein-test-refresh/expectations-project.
Looks like test-selector is nil in this case but test task seems to inherit it from :base profile.
So I merge :base profile in test-refresh then the issue is solved.