### PR TITLE
Add more details about the error if the compilation failed

### DIFF
--- a/test-refresh/src/com/jakemccrary/test_refresh.clj
+++ b/test-refresh/src/com/jakemccrary/test_refresh.clj
@@ -1,6 +1,7 @@
 (ns com.jakemccrary.test-refresh
   (:require clojure.java.shell
             clojure.pprint
+            [clojure.stacktrace :as stacktrace]
             [clojure.string :as str]
             clojure.test
             clojure.tools.namespace.dir
@@ -188,7 +189,9 @@
          result (if (= :ok refresh)
                   (run-selected-tests stack-depth test-paths selectors report namespaces-to-run)
                   {:status "Error"
-                   :message (str "Error refreshing environment: " clojure.core/*e)
+                   :message (str "Error refreshing environment: "
+                                 clojure.core/*e " "
+                                 (stacktrace/root-cause clojure.core/*e))
                    :exception clojure.core/*e})]
      (assoc result :run-time (- (System/currentTimeMillis) started)))))
 


### PR DESCRIPTION
Currently the error message looks like this:

`Error refreshing environment: Syntax error compiling at (a/b/c/namespace.clj:80:7). `

It's useful to add the error cause why is failed. i.e

`Error refreshing environment: Syntax error compiling at (a/b/c/namespace.clj:80:7). java.lang.RuntimeException: Unable to resolve symbol: x in this context`
